### PR TITLE
Add convenience script for metal platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ PXE files respectively to a volume that is bound into the container. Pass the
 destination path as an argument. For example:
 
     podman run --rm -v .:/data:bind /bin/copy-iso /data
+
+For the `copy-iso` script, if the `IP_OPTIONS` environment variable is
+non-empty then the output ISO will be configured to add the provided option to
+the kernel command line.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ destination path as an argument. For example:
 For the `copy-iso` script, if the `IP_OPTIONS` environment variable is
 non-empty then the output ISO will be configured to add the provided option to
 the kernel command line.
+
+The script `/bin/copy-metal` calls `copy-iso` and `copy-pxe` to copy the
+specific files needed for parts of the baremetal platform, depending on the
+first argument: `--all` for all files; `--pxe` for just the PXE files; or
+`--image-build` for just the ISO and initrd. In addition, symlinks are created
+so that filenames match the ones used in previous versions of the metal
+platform.

--- a/scripts/copy-iso
+++ b/scripts/copy-iso
@@ -19,11 +19,13 @@ copy_if_needed() {
         echo "${dest_file} is already up to date" >&2
     else
         rm -f "${dest_file}.sha256"
+        echo "Extracting ISO file" >&2
         if [ -n "${IP_OPTIONS:-}" ]; then
             echo "Adding kernel argument ${IP_OPTIONS}" >&2
             coreos-installer iso kargs modify -a "${IP_OPTIONS}" -o "${dest_file}" "${source}"
         else
             cp "${source}" "${DEST_DIR}"
+            echo "${dest_file}"
         fi
         cp "${source}.sha256" "${DEST_DIR}"
     fi

--- a/scripts/copy-iso
+++ b/scripts/copy-iso
@@ -19,7 +19,12 @@ copy_if_needed() {
         echo "${dest_file} is already up to date" >&2
     else
         rm -f "${dest_file}.sha256"
-        cp "${source}" "${DEST_DIR}"
+        if [ -n "${IP_OPTIONS:-}" ]; then
+            echo "Adding kernel argument ${IP_OPTIONS}" >&2
+            coreos-installer iso kargs modify -a "${IP_OPTIONS}" -o "${dest_file}" "${source}"
+        else
+            cp "${source}" "${DEST_DIR}"
+        fi
         cp "${source}.sha256" "${DEST_DIR}"
     fi
 }

--- a/scripts/copy-iso
+++ b/scripts/copy-iso
@@ -15,10 +15,12 @@ copy_if_needed() {
 
     dest_file="${DEST_DIR}/$(basename "${source}")"
 
-    if [ -f "${dest_file}" ] && [ "$(sha256sum "${dest_file}" | cut -d' ' -f1)" = "$(cat "${source}.sha256")" ]; then
+    if [ -f "${dest_file}" ] && [ "$(cat "${dest_file}.sha256")" = "$(cat "${source}.sha256")" ]; then
         echo "${dest_file} is already up to date" >&2
     else
+        rm -f "${dest_file}.sha256"
         cp "${source}" "${DEST_DIR}"
+        cp "${source}.sha256" "${DEST_DIR}"
     fi
 }
 

--- a/scripts/copy-metal
+++ b/scripts/copy-metal
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+script_dir="$(dirname "$0")"
+arch="$(uname -p)"
+
+custom=false
+fixed=false
+case "$1" in
+    --image-build)
+        shift
+        custom=true
+        ;;
+    --pxe)
+        shift
+        fixed=true
+        ;;
+    --all)
+        shift
+        ;&
+    *)
+        custom=true
+        fixed=true
+        ;;
+esac
+
+DEST_DIR="$1"
+
+if [ $fixed = true ]; then
+    "${script_dir}/copy-pxe" "${DEST_DIR}"
+    ln -f -s "coreos-${arch}-vmlinuz" "${DEST_DIR}/ironic-python-agent.kernel"
+    ln -f -s "coreos-${arch}-rootfs.img" "${DEST_DIR}/ironic-python-agent.rootfs"
+else
+    "${script_dir}/copy-pxe" --initrd-only "${DEST_DIR}"
+    rm -f "${DEST_DIR}"/coreos-*-vmlinuz "${DEST_DIR}"/coreos-*-rootfs.img
+fi
+
+if [ $custom = true ]; then
+    ln -f -s "coreos-${arch}-initrd.img" "${DEST_DIR}/ironic-python-agent.initramfs"
+
+    "${script_dir}/copy-iso" "${DEST_DIR}"
+    ln -f -s "coreos-${arch}.iso" "${DEST_DIR}/ironic-python-agent.iso"
+fi

--- a/scripts/copy-pxe
+++ b/scripts/copy-pxe
@@ -11,14 +11,12 @@ extract_if_needed() {
     local dest_base
     dest_base="${DEST_DIR}/$(basename --suffix=.iso "${source}")"
 
-    # TODO: arguably we should record the checksums of all these files at
-    # build time, so that we can verify the actual files and not just use the
-    # checksum file as a signal.
-    if [ -f "${dest_base}-vmlinuz" ] && [ -f "${dest_base}-initrd.img" ]&& [ -f "${dest_base}-rootfs.img" ] && [ -f "${dest_base}.iso.sha256" ] && [ "$(cat "${dest_base}.iso.sha256")" = "$(cat "${source}.sha256")" ]; then
+    if [ -f "${dest_base}-vmlinuz" ] && [ -f "${dest_base}-initrd.img" ]&& [ -f "${dest_base}-rootfs.img" ] && [ -f "${dest_base}.pxe.sha256" ] && [ "$(cat "${dest_base}.pxe.sha256")" = "$(cat "${source}.sha256")" ]; then
         echo "${dest_base}-[vmlinuz|initrd.img|rootfs.img] are already up to date" >&2
     else
+        rm -f "${dest_base}.pxe.sha256"
         coreos-installer iso extract pxe -o "${DEST_DIR}" "${source}"
-        cp "${source}.sha256" "${DEST_DIR}"
+        cp "${source}.sha256" "${dest_base}.pxe.sha256"
     fi
 }
 

--- a/scripts/copy-pxe
+++ b/scripts/copy-pxe
@@ -2,6 +2,11 @@
 
 set -e
 
+if [ "$1" = "--initrd-only" ]; then
+    INITRD_ONLY=true
+    shift
+fi
+
 ISO_DIR="/coreos"
 DEST_DIR="$1"
 
@@ -11,10 +16,19 @@ extract_if_needed() {
     local dest_base
     dest_base="${DEST_DIR}/$(basename --suffix=.iso "${source}")"
 
-    if [ -f "${dest_base}-vmlinuz" ] && [ -f "${dest_base}-initrd.img" ]&& [ -f "${dest_base}-rootfs.img" ] && [ -f "${dest_base}.pxe.sha256" ] && [ "$(cat "${dest_base}.pxe.sha256")" = "$(cat "${source}.sha256")" ]; then
-        echo "${dest_base}-[vmlinuz|initrd.img|rootfs.img] are already up to date" >&2
+    if [ -f "${dest_base}.pxe.sha256" ] && \
+       [ "$(cat "${dest_base}.pxe.sha256")" = "$(cat "${source}.sha256")" ] && \
+       [ -f "${dest_base}-initrd.img" ] && \
+       ( [[ "${INITRD_ONLY:-false}" =~ [Tt]rue ]] || \
+         [ -f "${dest_base}-vmlinuz" -a -f "${dest_base}-rootfs.img" ] ); then
+        if [ "$2" = "--initrd-only" ]; then
+            echo "${dest_base}-initrd.img is already up to date" >&2
+        else
+            echo "${dest_base}-[vmlinuz|initrd.img|rootfs.img] are already up to date" >&2
+        fi
     else
         rm -f "${dest_base}.pxe.sha256"
+        rm -f "${dest_base}-vmlinuz" "${dest_base}-initrd.img" "${dest_base}-rootfs.img"
         coreos-installer iso extract pxe -o "${DEST_DIR}" "${source}"
         cp "${source}.sha256" "${dest_base}.pxe.sha256"
     fi

--- a/scripts/copy-pxe
+++ b/scripts/copy-pxe
@@ -29,6 +29,7 @@ extract_if_needed() {
     else
         rm -f "${dest_base}.pxe.sha256"
         rm -f "${dest_base}-vmlinuz" "${dest_base}-initrd.img" "${dest_base}-rootfs.img"
+        echo "extracting PXE files..." >&2
         coreos-installer iso extract pxe -o "${DEST_DIR}" "${source}"
         cp "${source}.sha256" "${dest_base}.pxe.sha256"
     fi


### PR DESCRIPTION
Add a script that does everything we want in the various places this is
to be used in the metal platform, with the first argument specifying
which:

* `--all` for the installer bootstrap
* `--pxe` for the metal3 Deployment
* `--image-build` for the image-customization-controller

Also create symlinks to the existing ironic-python-agent.* filenames so
that no code in the installer or cluster-baremetal-operator has to
change to reference the right files.

Add support for the `IP_OPTIONS` environment variable to customise the kernel command line when extracting the ISO.