### PR TITLE
Add to release payload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,6 @@ COPY --from=builder /usr/bin/coreos-installer /usr/bin/
 COPY --from=builder /output/coreos/* /coreos/
 
 COPY scripts/* /bin/
+
+# Include this container in the release image payload
+LABEL io.openshift.release.operator=true


### PR DESCRIPTION
We want machine-os-images to be available in the release payload, so
label it with io.openshift-release-operator=true to ensure that it is
included.

We could wait for it to be referenced by the CBO, but labelling the image now means that we can use it immediately for testing both CBO and Installer PRs. Also, were CBO to ever stop using this, we would probably not want it to drop out of the payload immediately, since other uses are likely to accumulate over time.

The downstream image has been built and [is available,](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/k8s/ns/ocp/imagestreamtags/4.10-art-latest%3Amachine-os-images) so it is safe to add this tag without breaking the nightly build.