### PR TITLE
Bug 2075024: Remove destination coreos if it exists

### DIFF
--- a/scripts/copy-iso
+++ b/scripts/copy-iso
@@ -22,6 +22,7 @@ copy_if_needed() {
         echo "Extracting ISO file" >&2
         if [ -n "${IP_OPTIONS:-}" ]; then
             echo "Adding kernel argument ${IP_OPTIONS}" >&2
+            rm -f "${dest_file}"
             coreos-installer iso kargs modify -a "${IP_OPTIONS}" -o "${dest_file}" "${source}"
         else
             cp "${source}" "${DEST_DIR}"


### PR DESCRIPTION
Multiple runs of copy-iso results in coreos-installer
trying to overwrite a file which it refuses to do.