### PR TITLE
Revert .ci-operator.yaml 

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  name: release
-  namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.11
+  name: shellcheck
+  namespace: ci
+  tag: latest


### PR DESCRIPTION
This reverts .ci-operator.yaml change introduced by commit https://github.com/openshift/machine-os-images/commit/91a08225f2a2c094729a3ca9225bbdd3633cf740.

PR https://github.com/openshift/ocp-build-data/pull/1621 will make sure future ART reconciliation PRs will not change .ci-operator.yaml in the future.