### PR TITLE
[release-4.10] Revert .ci-operator.yaml

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  name: release
-  namespace: openshift
-  tag: rhel-8-release-golang-1.17-openshift-4.10
+  name: shellcheck
+  namespace: ci
+  tag: latest


### PR DESCRIPTION
This is a manual cherry pick of https://github.com/openshift/machine-os-images/pull/16.

Also https://github.com/openshift/ocp-build-data/pull/1622 makes sure art-bot will not change that file in the future.