### PR TITLE
Force updating rhcos image to version 413.92.202303190222-0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ first argument: `--all` for all files; `--pxe` for just the PXE files; or
 `--image-build` for just the ISO and initrd. In addition, symlinks are created
 so that filenames match the ones used in previous versions of the metal
 platform.
+
+ 


### PR DESCRIPTION
The latest CI stream image seems to be stale on branch 4.13 (still pointing to 413.86.202302150245-0). This patch it's just for triggering the CI image rebuild for such branch, given than https://github.com/openshift/installer/pull/6997 recently merged, and it's also required for agent based installer jobs.