### PR TITLE
NO-ISSUE: Force updating 4.15 CI images

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ first argument: `--all` for all files; `--pxe` for just the PXE files; or
 `--image-build` for just the ISO and initrd. In addition, symlinks are created
 so that filenames match the ones used in previous versions of the metal
 platform.
- 
+


### PR DESCRIPTION
The current 4.15 OKD CI image `registry.ci.openshift.org/origin/4.15:machine-os-images`, which is included into the ephemeral release payloads for presubmit PR jobs, is out of sync and does not reference the requires FCOS images.

Required by https://github.com/openshift/installer/pull/7641