### PR TITLE
NO-ISSUE: Dummy change to force bumping fcos image to 39.20231101.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,3 @@ first argument: `--all` for all files; `--pxe` for just the PXE files; or
 `--image-build` for just the ISO and initrd. In addition, symlinks are created
 so that filenames match the ones used in previous versions of the metal
 platform.
-


### PR DESCRIPTION
Since metadata were recently updated in https://github.com/openshift/installer/pull/7779