### PR TITLE
OCPBUGS-44889: Allow external configuration of download host for production builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.ci.openshift.org/ocp/4.18:installer AS builder
 
 ARG DIRECT_DOWNLOAD=false
+ENV ISO_HOST=https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com
 
 USER root:root
 

--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -29,7 +29,7 @@ download_url() {
     local iso_sha256
     iso_sha256="$(image_data "${arch}" sha256)"
 
-    wget "$@" "${url}" -O "${iso_file}"
+    wget --quiet "$@" "${url}" -O "${iso_file}"
     local actual_sha256
     actual_sha256="$(sha256sum "${iso_file}" | cut -d' ' -f1)"
     if [ "${actual_sha256}" != "${iso_sha256}" ]; then
@@ -45,7 +45,7 @@ download_art_arch() {
 
     local origurl
     origurl="$(image_data "${arch}" location)"
-    local url="https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/${origurl#*.com/art/}"
+    local url="$ISO_HOST/${origurl#*.com/art/}"
 
     download_url "${arch}" "${url}" --no-check-certificate  # skipping certificate check is ok because we will check its sha256 in any case.
 }


### PR DESCRIPTION
Would need to go in tandem with https://github.com/openshift-eng/ocp-build-data/pull/5724