### PR TITLE
NO-ISSUE: Run fetch_image with tracing

### DIFF
--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 ISO_ARCH="${ISO_ARCH:-$(uname -p)}"
 OUTPUT_DIR="coreos"


### PR DESCRIPTION
This way it's much easier to understand what gets downloaded during the
build (e.g. CoreOS version).

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
