### PR TITLE
METAL-1730: Add stream symlinks for multi-stream support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/4.22:installer AS builder
 
 ARG DIRECT_DOWNLOAD=false
-ARG COREOS_VERSIONS=9
+ARG COREOS_VERSIONS=9,10
 ENV ISO_HOST=https://releases-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com
 ENV COREOS_VERSIONS=${COREOS_VERSIONS}
 # NOTE(elfosardo): dummy env variable to update when we need to rebuild the image without

--- a/scripts/copy-metal
+++ b/scripts/copy-metal
@@ -118,3 +118,45 @@ if [ $custom = true ]; then
         ln -f -s "${coreos_name}-aarch64.iso" "${DEST_DIR}/ironic-python-agent_aarch64.iso"
     fi
 fi
+
+# Create stream-prefixed IPA symlinks for all available CoreOS versions.
+# These allow the image-customization-controller to discover images by OS
+# stream (e.g., rhel-9, rhel-10) via the coreos.openshift.io/stream label.
+for prefix in coreos coreos10; do
+    stream_json="/coreos/${prefix}-stream.json"
+    if [ ! -f "${stream_json}" ]; then
+        continue
+    fi
+
+    case "${prefix}" in
+        coreos) stream="rhel-9" ;;
+        coreos10) stream="rhel-10" ;;
+    esac
+
+    if [ $custom = true ]; then
+        ln -f -s "${prefix}-${arch}.iso" "${DEST_DIR}/ironic-python-agent-${stream}.iso"
+        ln -f -s "${prefix}-${arch}.iso" "${DEST_DIR}/ironic-python-agent-${stream}_${arch}.iso"
+        ln -f -s "${prefix}-${arch}-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}.initramfs"
+        ln -f -s "${prefix}-${arch}-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}_${arch}.initramfs"
+
+        if [[ "${arch}" == "x86_64" ]]; then
+            ln -f -s "${prefix}-aarch64.iso" "${DEST_DIR}/ironic-python-agent-${stream}_aarch64.iso"
+            ln -f -s "${prefix}-aarch64-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}_aarch64.initramfs"
+        fi
+    fi
+
+    if [ $fixed = true ]; then
+        ln -f -s "${prefix}-${arch}-vmlinuz" "${DEST_DIR}/ironic-python-agent-${stream}.kernel"
+        ln -f -s "${prefix}-${arch}-vmlinuz" "${DEST_DIR}/ironic-python-agent-${stream}_${arch}.kernel"
+        ln -f -s "${prefix}-${arch}-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}.initramfs"
+        ln -f -s "${prefix}-${arch}-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}_${arch}.initramfs"
+        ln -f -s "${prefix}-${arch}-rootfs.img" "${DEST_DIR}/ironic-python-agent-${stream}.rootfs"
+        ln -f -s "${prefix}-${arch}-rootfs.img" "${DEST_DIR}/ironic-python-agent-${stream}_${arch}.rootfs"
+
+        if [[ "${arch}" == "x86_64" ]]; then
+            ln -f -s "${prefix}-aarch64-vmlinuz" "${DEST_DIR}/ironic-python-agent-${stream}_aarch64.kernel"
+            ln -f -s "${prefix}-aarch64-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}_aarch64.initramfs"
+            ln -f -s "${prefix}-aarch64-rootfs.img" "${DEST_DIR}/ironic-python-agent-${stream}_aarch64.rootfs"
+        fi
+    fi
+done

--- a/scripts/copy-metal
+++ b/scripts/copy-metal
@@ -118,3 +118,55 @@ if [ $custom = true ]; then
         ln -f -s "${coreos_name}-aarch64.iso" "${DEST_DIR}/ironic-python-agent_aarch64.iso"
     fi
 fi
+
+# Create stream-prefixed IPA symlinks for all available CoreOS versions.
+# These allow the image-customization-controller to discover images by OS
+# stream (e.g., rhel-9, rhel-10) via the coreos.openshift.io/stream label.
+for prefix in coreos coreos10; do
+    stream_json="/coreos/${prefix}-stream.json"
+    if [ ! -f "${stream_json}" ]; then
+        continue
+    fi
+
+    case "${prefix}" in
+        coreos) stream="rhel-9" ;;
+        coreos10) stream="rhel-10" ;;
+    esac
+
+    if [ $custom = true ]; then
+        ln -f -s "${prefix}-${arch}.iso" "${DEST_DIR}/ironic-python-agent-${stream}.iso"
+        ln -f -s "${prefix}-${arch}.iso" "${DEST_DIR}/ironic-python-agent-${stream}_${arch}.iso"
+        ln -f -s "${prefix}-${arch}-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}.initramfs"
+        ln -f -s "${prefix}-${arch}-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}_${arch}.initramfs"
+
+        if [[ "${arch}" == "x86_64" ]]; then
+            if [ -f "${DEST_DIR}/${prefix}-aarch64.iso" ]; then
+                ln -f -s "${prefix}-aarch64.iso" "${DEST_DIR}/ironic-python-agent-${stream}_aarch64.iso"
+            fi
+            if [ -f "${DEST_DIR}/${prefix}-aarch64-initrd.img" ]; then
+                ln -f -s "${prefix}-aarch64-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}_aarch64.initramfs"
+            fi
+        fi
+    fi
+
+    if [ $fixed = true ]; then
+        ln -f -s "${prefix}-${arch}-vmlinuz" "${DEST_DIR}/ironic-python-agent-${stream}.kernel"
+        ln -f -s "${prefix}-${arch}-vmlinuz" "${DEST_DIR}/ironic-python-agent-${stream}_${arch}.kernel"
+        ln -f -s "${prefix}-${arch}-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}.initramfs"
+        ln -f -s "${prefix}-${arch}-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}_${arch}.initramfs"
+        ln -f -s "${prefix}-${arch}-rootfs.img" "${DEST_DIR}/ironic-python-agent-${stream}.rootfs"
+        ln -f -s "${prefix}-${arch}-rootfs.img" "${DEST_DIR}/ironic-python-agent-${stream}_${arch}.rootfs"
+
+        if [[ "${arch}" == "x86_64" ]]; then
+            if [ -f "${DEST_DIR}/${prefix}-aarch64-vmlinuz" ]; then
+                ln -f -s "${prefix}-aarch64-vmlinuz" "${DEST_DIR}/ironic-python-agent-${stream}_aarch64.kernel"
+            fi
+            if [ -f "${DEST_DIR}/${prefix}-aarch64-initrd.img" ]; then
+                ln -f -s "${prefix}-aarch64-initrd.img" "${DEST_DIR}/ironic-python-agent-${stream}_aarch64.initramfs"
+            fi
+            if [ -f "${DEST_DIR}/${prefix}-aarch64-rootfs.img" ]; then
+                ln -f -s "${prefix}-aarch64-rootfs.img" "${DEST_DIR}/ironic-python-agent-${stream}_aarch64.rootfs"
+            fi
+        fi
+    fi
+done


### PR DESCRIPTION
Create ironic-python-agent-{stream} symlinks (e.g., ironic-python-agent-rhel-9.iso, ironic-python-agent-rhel-10.iso) for all available CoreOS versions. These allow the image-customization-controller to discover and serve different CoreOS base images based on the coreos.openshift.io/stream label.

### How it works

The `coreos.openshift.io/stream` label on a BareMetalHost determines
which kernel, initrd, and rootfs files are used during PXE boot. For
example, a BMH labeled `coreos.openshift.io/stream: rhel-10` will PXE
boot with `ironic-python-agent-rhel-10.kernel`,
`ironic-python-agent-rhel-10.initramfs`, and
`ironic-python-agent-rhel-10.rootfs` instead of the unqualified defaults.

The per-node `coreos.live.rootfs_url` kernel parameter set via ICC's
`ExtraKernelParams` overrides the global one from ironic-image because
dracut's `getarg` returns the last value for duplicate parameters.

### Changes across repos

**installer** ([openshift/installer#10502](https://github.com/openshift/installer/pull/10502))
— `pkg/asset/machines/baremetal/`: Sets the `coreos.openshift.io/stream`
label on all generated BareMetalHost objects (control-plane, worker,
arbiter) based on the install-config's `OSImageStream` setting, defaulting
to `rhel-9`. Configures `hostSelector.matchLabels` on
BareMetalMachineProviderSpec so MachineSets only claim BMHs with the
matching stream label.

**cluster-baremetal-operator** ([openshift/cluster-baremetal-operator#590](https://github.com/openshift/cluster-baremetal-operator/pull/590))
— `provisioning/image_customization.go`: Passes three new environment
variables to the ICC container: `DEPLOY_KERNEL` (path to the kernel file),
`IMAGE_SHARED_DIR` (path to the shared images directory where
stream-prefixed files are discovered), and `IRONIC_ROOTFS_URL` (base URL
for the rootfs served by httpd). These enable ICC to discover multi-stream
images and construct per-node kernel/rootfs URLs.

**machine-os-images** ([openshift/machine-os-images#83](https://github.com/openshift/machine-os-images/pull/83))
— `scripts/copy-metal`: Creates stream-prefixed IPA symlinks (e.g.
`ironic-python-agent-rhel-9.iso`, `ironic-python-agent-rhel-10.kernel`)
for all available CoreOS versions, allowing ICC to discover images by
stream. Also fixes missing initramfs symlinks in the `fixed=true` (PXE)
block — without these, a stream-specific kernel would be paired with the
default-stream initrd, causing a version mismatch that crashes immediately
on PXE boot.

**image-customization-controller** ([openshift/image-customization-controller#175](https://github.com/openshift/image-customization-controller/pull/175))
— `pkg/imagehandler/`, `pkg/imageprovider/rhcos.go`: Adds OS stream
selection so ICC can serve different CoreOS base images based on the
`coreos.openshift.io/stream` label. Images are indexed by (stream,
architecture) and discovered from stream-prefixed filenames. Key changes:

- `streamArchSpecificURL()` transforms the base rootfs URL into a stream-
  and arch-specific URL
- `BuildImage()` passes the stream to `ServeKernel()` and uses the
  stream-specific rootfs URL in `ExtraKernelParams`
- `imageKey()` includes the stream in the cache key so that changing a
  BMH's stream label invalidates the cached image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process to properly support multiple OS stream versions, ensuring artifacts are correctly available for RHEL 9 and RHEL 10 installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->