### PR TITLE
OCPBUGS-85476: Force rebuild for OCP 5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV ISO_HOST=https://releases-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-d
 ENV COREOS_VERSIONS=${COREOS_VERSIONS}
 # NOTE(elfosardo): dummy env variable to update when we need to rebuild the image without
 # actual changes; output of `date +%Y-%m-%d_%H-%M-%S`
-ENV DUMMY_REBUILD_TIMESTAMP=2025-10-03_18-18-19
+ENV DUMMY_REBUILD_TIMESTAMP=2026-05-12_14-29-09
 
 USER root:root
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image rebuild configuration to ensure fresh container builds on deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->