### PR TITLE
OCPBUGS-87871: Add support for hermetic builds via Cachi2 prefetched CoreOS ISOs

### DIFF
--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -5,6 +5,7 @@ set -ex
 ISO_ARCH="${ISO_ARCH:-$(uname -m)}"
 OUTPUT_DIR="coreos"
 COREOS_VERSIONS="${COREOS_VERSIONS:-9}"
+CACHI2_GENERIC_DIR="/cachi2/output/deps/generic"
 
 stream_name_for_version() {
     local version="$1"
@@ -88,12 +89,41 @@ download_direct_arch() {
     download_url "${file_prefix}" "${data_file}" "${arch}" "${url}"
 }
 
+copy_from_cachi2() {
+    local file_prefix="$1"
+    local data_file="$2"
+    local arch="$3"
+
+    local iso_file="${file_prefix}-${arch}.iso"
+    local cachi2_iso="${CACHI2_GENERIC_DIR}/${iso_file}"
+
+    if [ ! -f "${cachi2_iso}" ]; then
+        echo "ISO not found in Cachi2 directory: ${cachi2_iso}" >&2
+        exit 1
+    fi
+
+    cp "${cachi2_iso}" "${iso_file}"
+
+    local iso_sha256
+    iso_sha256="$(image_data "${data_file}" "${arch}" sha256)"
+    local actual_sha256
+    actual_sha256="$(sha256sum "${iso_file}" | cut -d' ' -f1)"
+    if [ "${actual_sha256}" != "${iso_sha256}" ]; then
+        echo "Invalid checksum  ${actual_sha256}" >&2
+        echo "Expected checksum ${iso_sha256}" >&2
+        exit 1
+    fi
+    printf "%s" "${iso_sha256}" >"${iso_file}.sha256"
+}
+
 download_arch() {
     local file_prefix="$1"
     local data_file="$2"
     local arch="$3"
 
-    if [[ "${DIRECT_DOWNLOAD:-false}" =~ [Tt]rue ]]; then
+    if [ -d "${CACHI2_GENERIC_DIR}" ]; then
+        copy_from_cachi2 "${file_prefix}" "${data_file}" "${arch}"
+    elif [[ "${DIRECT_DOWNLOAD:-false}" =~ [Tt]rue ]]; then
         download_direct_arch "${file_prefix}" "${data_file}" "${arch}"
     else
         download_art_arch "${file_prefix}" "${data_file}" "${arch}"


### PR DESCRIPTION
## Summary

`ose-machine-os-images` can't build hermetically in Konflux because `fetch_image.sh` downloads RHCOS ISO images at build time from an internal mirror.

This adds support for Cachi2 generic artifact prefetching. When the Cachi2 prefetch directory (`/cachi2/output/deps/generic/`) exists, `fetch_image.sh` copies ISOs from there instead of downloading them. The SHA256 checksum of each prefetched ISO is verified against the output of `openshift-install coreos print-stream-json`, ensuring the ISOs are identical to what would be downloaded in a non-hermetic build. Non-hermetic builds continue to work as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving ISO artifacts from a local Cachi2 generic output directory.
  * Improved artifact retrieval logic with fallback handling.
  * ISO downloads now include SHA256 checksum verification against expected values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->