### PR TITLE
ART-21512: Fix OKD builds to use centos streams instead of rhel

### DIFF
--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -9,9 +9,17 @@ CACHI2_GENERIC_DIR="/cachi2/output/deps/generic"
 
 stream_name_for_version() {
     local version="$1"
+    local prefix="rhel"
+
+    # Detect OKD builds - use centos streams instead of rhel
+    # ART injects TAGS='scos' for OKD builds
+    if [[ "${TAGS:-}" == *scos* ]]; then
+        prefix="centos"
+    fi
+
     case "${version}" in
-        9) echo "rhel-9" ;;
-        10) echo "rhel-10" ;;
+        9) echo "${prefix}-9" ;;
+        10) echo "${prefix}-10" ;;
         *)
             echo "Unknown CoreOS version: ${version}" >&2
             exit 1
@@ -138,7 +146,11 @@ for version in ${COREOS_VERSIONS}; do
     file_prefix="$(file_prefix_for_version "${version}")"
     stream_data_file="${file_prefix}-stream.json"
 
-    openshift-install coreos print-stream-json --stream "${stream_name}" >"${stream_data_file}"
+    # Try to get stream data; skip this version if openshift-install doesn't support it
+    if ! openshift-install coreos print-stream-json --stream "${stream_name}" >"${stream_data_file}" 2>/dev/null; then
+        echo "Skipping CoreOS ${version} (stream: ${stream_name}) - not supported by openshift-install" >&2
+        continue
+    fi
 
     echo "Downloading CoreOS ${version} (stream: ${stream_name}) for ${ISO_ARCH}"
     download_arch "${file_prefix}" "${stream_data_file}" "${ISO_ARCH}"


### PR DESCRIPTION
## Summary

OKD builds use CentOS Stream CoreOS, not RHEL CoreOS. The `openshift-install` binary in OKD 5.0 only recognizes `centos-*` streams (specifically `centos-10`), not `rhel-*` streams.

## Problem

OKD 5.0 builds started failing after PR #95 was merged (which added support for multiple CoreOS versions via `COREOS_VERSIONS=9,10`):

```
openshift-install coreos print-stream-json --stream rhel-9
level=fatal msg=Error executing openshift-install: invalid value "rhel-9" for --stream; must be one of [centos-10]
```

## Root Cause

The `openshift-install` binary in the OKD `ose-installer-rhel9` image changed between 2026-06-13 and 2026-06-14 to only support CentOS streams. The `fetch_image.sh` script was hardcoded to use `rhel-*` stream names for both OCP and OKD.

Additionally, OKD 5.0's `openshift-install` only supports `centos-10`, not `centos-9`, so the script needs to gracefully handle unsupported streams.

## Solution

### 1. Detect OKD vs OCP builds

Check the `TAGS` environment variable that ART injects:
- **OKD builds**: `TAGS='scos'` → use `centos-9`, `centos-10`
- **OCP builds**: `TAGS` unset or doesn't contain 'scos' → use `rhel-9`, `rhel-10`

### 2. Skip unsupported streams

Instead of failing when `openshift-install` doesn't support a requested stream, log a warning and skip that version:

```bash
if ! openshift-install coreos print-stream-json --stream "${stream_name}" >"${stream_data_file}" 2>/dev/null; then
    echo "Skipping CoreOS ${version} (stream: ${stream_name}) - not supported" >&2
    continue
fi
```

This allows builds to succeed even when `COREOS_VERSIONS=9,10` but only version 10 is supported.

## Testing
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fokd/1306/
[ose-machine-os-images-container-v5.0.0-202607031341.p2.g9a06f12.assembly.stream.scos10](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=ose-machine-os-images-container-v5.0.0-202607031341.p2.g9a06f12.assembly.stream.scos10&record_id=12a77545-e793-3e9b-e5fb-e9d247a8f0fc&group=okd-5.0&outcome=success&type=image)

https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/ose-5-0-ose-machine-os-images-5z9pw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CoreOS image selection now matches the build type more accurately.
  * Builds tagged for OKD now use the CentOS-based stream, while other builds continue to use the RHEL-based stream.
  * Stream names now vary correctly by CoreOS version, improving image fetch consistency.
  * The installer now skips unsupported CoreOS streams gracefully instead of failing or repeatedly probing unavailable streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->