### PR TITLE
OKD-429: Fix OKD/SCOS builds to use centos CoreOS streams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM registry.ci.openshift.org/ocp/5.0:installer AS builder
 
 ARG DIRECT_DOWNLOAD=false
 ARG COREOS_VERSIONS=9,10
+ARG TAGS=""
 ENV ISO_HOST=https://releases-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com
 ENV COREOS_VERSIONS=${COREOS_VERSIONS}
+ENV TAGS=${TAGS}
 # NOTE(elfosardo): dummy env variable to update when we need to rebuild the image without
 # actual changes; output of `date +%Y-%m-%d_%H-%M-%S`
 ENV DUMMY_REBUILD_TIMESTAMP=2026-05-12_14-29-09

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM registry.ci.openshift.org/ocp/5.0:installer AS builder
 
 ARG DIRECT_DOWNLOAD=false
 ARG COREOS_VERSIONS=9,10
-ARG TAGS=""
 ENV ISO_HOST=https://releases-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com
 ENV COREOS_VERSIONS=${COREOS_VERSIONS}
-ENV TAGS=${TAGS}
 # NOTE(elfosardo): dummy env variable to update when we need to rebuild the image without
 # actual changes; output of `date +%Y-%m-%d_%H-%M-%S`
 ENV DUMMY_REBUILD_TIMESTAMP=2026-05-12_14-29-09

--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -9,18 +9,21 @@ CACHI2_GENERIC_DIR="/cachi2/output/deps/generic"
 
 stream_name_for_version() {
     local version="$1"
-    local rhel_name="rhel-${version}"
-    local centos_name="centos-${version}"
+    local prefix="rhel"
 
-    # Try rhel first (OCP), fall back to centos (OKD/SCOS)
-    if openshift-install coreos print-stream-json --stream "${rhel_name}" >/dev/null 2>&1; then
-        echo "${rhel_name}"
-    elif openshift-install coreos print-stream-json --stream "${centos_name}" >/dev/null 2>&1; then
-        echo "${centos_name}"
-    else
-        echo "No supported CoreOS stream found for version ${version} (tried ${rhel_name}, ${centos_name})" >&2
-        exit 1
+    # OKD/SCOS builds use CentOS Stream CoreOS instead of RHEL CoreOS
+    if [[ "${TAGS:-}" == *scos* ]]; then
+        prefix="centos"
     fi
+
+    case "${version}" in
+        9) echo "${prefix}-9" ;;
+        10) echo "${prefix}-10" ;;
+        *)
+            echo "Unknown CoreOS version: ${version}" >&2
+            exit 1
+            ;;
+    esac
 }
 
 file_prefix_for_version() {

--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -12,16 +12,15 @@ stream_name_for_version() {
     local prefix="rhel"
 
     # OKD/SCOS builds run on CentOS and use CentOS Stream CoreOS
+    # shellcheck source=/dev/null
     source /etc/os-release
     if [[ "${ID}" == "centos" ]]; then
         prefix="centos"
     fi
 
-    case "${prefix}-${version}" in
-        centos-9)
-            echo "Skipping CoreOS ${version}: ${prefix}-${version} is not supported" >&2
-            ;;
-        rhel-9|rhel-10|centos-10) echo "${prefix}-${version}" ;;
+    case "${version}" in
+        9) echo "${prefix}-9" ;;
+        10) echo "${prefix}-10" ;;
         *)
             echo "Unknown CoreOS version: ${version}" >&2
             exit 1
@@ -145,9 +144,6 @@ COREOS_VERSIONS="${COREOS_VERSIONS//,/ }"
 
 for version in ${COREOS_VERSIONS}; do
     stream_name="$(stream_name_for_version "${version}")"
-    if [[ -z "${stream_name}" ]]; then
-        continue
-    fi
     file_prefix="$(file_prefix_for_version "${version}")"
     stream_data_file="${file_prefix}-stream.json"
 

--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -11,8 +11,9 @@ stream_name_for_version() {
     local version="$1"
     local prefix="rhel"
 
-    # OKD/SCOS builds use CentOS Stream CoreOS instead of RHEL CoreOS
-    if [[ "${TAGS:-}" == *scos* ]]; then
+    # OKD/SCOS builds run on CentOS and use CentOS Stream CoreOS
+    source /etc/os-release
+    if [[ "${ID}" == "centos" ]]; then
         prefix="centos"
     fi
 

--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -17,9 +17,11 @@ stream_name_for_version() {
         prefix="centos"
     fi
 
-    case "${version}" in
-        9) echo "${prefix}-9" ;;
-        10) echo "${prefix}-10" ;;
+    case "${prefix}-${version}" in
+        centos-9)
+            echo "Skipping CoreOS ${version}: ${prefix}-${version} is not supported" >&2
+            ;;
+        rhel-9|rhel-10|centos-10) echo "${prefix}-${version}" ;;
         *)
             echo "Unknown CoreOS version: ${version}" >&2
             exit 1
@@ -143,6 +145,9 @@ COREOS_VERSIONS="${COREOS_VERSIONS//,/ }"
 
 for version in ${COREOS_VERSIONS}; do
     stream_name="$(stream_name_for_version "${version}")"
+    if [[ -z "${stream_name}" ]]; then
+        continue
+    fi
     file_prefix="$(file_prefix_for_version "${version}")"
     stream_data_file="${file_prefix}-stream.json"
 

--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -9,9 +9,16 @@ CACHI2_GENERIC_DIR="/cachi2/output/deps/generic"
 
 stream_name_for_version() {
     local version="$1"
+    local prefix="rhel"
+
+    # OKD/SCOS builds use CentOS Stream CoreOS instead of RHEL CoreOS
+    if [[ "${TAGS:-}" == *scos* ]]; then
+        prefix="centos"
+    fi
+
     case "${version}" in
-        9) echo "rhel-9" ;;
-        10) echo "rhel-10" ;;
+        9) echo "${prefix}-9" ;;
+        10) echo "${prefix}-10" ;;
         *)
             echo "Unknown CoreOS version: ${version}" >&2
             exit 1

--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -18,11 +18,10 @@ stream_name_for_version() {
         prefix="centos"
     fi
 
-    case "${version}" in
-        9) echo "${prefix}-9" ;;
-        10) echo "${prefix}-10" ;;
+    case "${prefix}-${version}" in
+        rhel-9|rhel-10|centos-10) echo "${prefix}-${version}" ;;
         *)
-            echo "Unknown CoreOS version: ${version}" >&2
+            echo "Unsupported CoreOS stream: ${prefix}-${version}" >&2
             exit 1
             ;;
     esac

--- a/fetch_image.sh
+++ b/fetch_image.sh
@@ -9,21 +9,18 @@ CACHI2_GENERIC_DIR="/cachi2/output/deps/generic"
 
 stream_name_for_version() {
     local version="$1"
-    local prefix="rhel"
+    local rhel_name="rhel-${version}"
+    local centos_name="centos-${version}"
 
-    # OKD/SCOS builds use CentOS Stream CoreOS instead of RHEL CoreOS
-    if [[ "${TAGS:-}" == *scos* ]]; then
-        prefix="centos"
+    # Try rhel first (OCP), fall back to centos (OKD/SCOS)
+    if openshift-install coreos print-stream-json --stream "${rhel_name}" >/dev/null 2>&1; then
+        echo "${rhel_name}"
+    elif openshift-install coreos print-stream-json --stream "${centos_name}" >/dev/null 2>&1; then
+        echo "${centos_name}"
+    else
+        echo "No supported CoreOS stream found for version ${version} (tried ${rhel_name}, ${centos_name})" >&2
+        exit 1
     fi
-
-    case "${version}" in
-        9) echo "${prefix}-9" ;;
-        10) echo "${prefix}-10" ;;
-        *)
-            echo "Unknown CoreOS version: ${version}" >&2
-            exit 1
-            ;;
-    esac
 }
 
 file_prefix_for_version() {


### PR DESCRIPTION
## Summary

- `fetch_image.sh` hardcodes `rhel-9`/`rhel-10` as CoreOS stream names, which fails when the OKD installer is used (it only recognizes `centos-*` streams like `centos-10`)
- Detects OKD builds via the `TAGS` build arg (set to `scos` by CI for OKD builds) and uses `centos-*` stream names accordingly
- Adds `ARG`/`ENV` declarations for `TAGS` in the Dockerfile so the build arg is available to `fetch_image.sh` during the image build

## Context

This fixes the source-level issue behind the `machine-os-images` build failure seen in [openshift/release#83137](https://github.com/openshift/release/pull/83137) (adding 4.22 OKD configs). The failure occurs because:

1. The **4.21 OKD CI config** had no installer image override, so it silently used OCP's RHEL-based installer where `--stream rhel-9` was valid
2. The **main config** (and the new 4.22 config via `config-brancher`) correctly overrides the installer with the OKD installer (`origin_scos-5.0_installer`), which only supports `centos-*` streams
3. `fetch_image.sh` calls `openshift-install coreos print-stream-json --stream rhel-9` and gets:
   ```
   level=fatal msg=Error executing openshift-install: invalid value "rhel-9" for --stream; must be one of [centos-10]
   ```

An [ocp-build-data workaround](https://github.com/openshift-eng/ocp-build-data/pull/11799) (merged July 2026) patches `fetch_image.sh` at ART build time via `sed`, but does **not** apply to CI builds which run via `ci-operator` directly from source. This PR fixes the issue at the source level.

Same approach as [PR #107](https://github.com/openshift/machine-os-images/pull/107), without the `2>/dev/null` error suppression that was [objected to in review](https://github.com/openshift/machine-os-images/pull/107).

## Required companion fix in openshift/release

This PR alone is necessary but **not sufficient** for the OKD CI job to pass. The CI config in `openshift/release` (`openshift-machine-os-images-main__okd-scos.yaml`) has two additional issues that need a companion PR:

1. **Version mismatch in installer override** — the `inputs.as` references `registry.ci.openshift.org/ocp/4.22:installer` but the Dockerfile `FROM` uses `registry.ci.openshift.org/ocp/5.0:installer`. Since ci-operator matches by image reference, the override never takes effect and the OCP installer is used instead of the OKD installer. The `as` entries need to reference `ocp/5.0:*` to match.

2. **COREOS_VERSIONS needs to be "10" for OKD** — OKD 5.0 only supports `centos-10` (no `centos-9`), but the Dockerfile defaults to `COREOS_VERSIONS=9,10`. The CI config needs a build arg override: `COREOS_VERSIONS=10`.

## Test plan

- [ ] OKD/SCOS CI build passes (requires companion openshift/release fix)
- [ ] OCP CI build continues to pass (`ci/prow/images` — `TAGS` defaults to empty, so `rhel-*` streams are used) ✅ already passing
- [ ] shellcheck passes ✅ already passing